### PR TITLE
Disable web workers

### DIFF
--- a/src/juicy-ace-editor.html
+++ b/src/juicy-ace-editor.html
@@ -81,6 +81,7 @@
             editor.setFontSize( this.getAttribute("fontsize") );
             editor.setReadOnly( this.getAttribute("readonly") );
             var session = editor.getSession();
+            session.setUseWorker(false);
             session.setMode( this.getAttribute("mode") );
             session.setUseSoftTabs( this.getAttribute("softtabs") );
             this.getAttribute("tabsize") && session.setTabSize( this.getAttribute("tabsize") );


### PR DESCRIPTION
The way we use ace editor causes there to be a thread leak if we
allow ace editor to use worker threads
